### PR TITLE
Fix permissions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ In this version the tool works outside the Proxmox VE host using the API. The re
 
 ## Permission
 
-For execution is required permission: VM.Audit, VM.Snapshot, Datastore.Audit, Pool.Allocate.
+For execution is required permission: VM.Audit, VM.Snapshot, Datastore.Audit, Pool.Audit.
 
 ## Api token
 


### PR DESCRIPTION
Looks like a typo in the required permissions section of the readme.